### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,6 +87,9 @@ jobs:
     needs: [build, provenance]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+      actions: read
     steps:
       - name: Download linux binaries
         uses: actions/download-artifact@v4.3.0


### PR DESCRIPTION
Potential fix for [https://github.com/PKopel/mact/security/code-scanning/3](https://github.com/PKopel/mact/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the `release` job. This block should specify the minimal permissions required for the job to function correctly. Based on the job's actions (e.g., downloading artifacts and uploading assets to a release), the following permissions are necessary:
- `contents: write` to upload assets to a GitHub release.
- `actions: read` to interact with GitHub Actions workflows (if needed for artifact handling).

The `permissions` block will be added to the `release` job definition in the `.github/workflows/release.yaml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
