### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   GO_VERSION: "1.23"
 


### PR DESCRIPTION
Potential fix for [https://github.com/PKopel/mact/security/code-scanning/2](https://github.com/PKopel/mact/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only checks out code and runs tests, it does not require write permissions. The minimal required permission is `contents: read`, which allows the workflow to access the repository's contents without modifying them. This change will ensure that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
